### PR TITLE
Fix:Redundant occurrunces of DefaultClientSuggestions Adapter removed

### DIFF
--- a/searchwidget/src/main/java/com/harsh/searchwidget/SearchBar.java
+++ b/searchwidget/src/main/java/com/harsh/searchwidget/SearchBar.java
@@ -1110,19 +1110,9 @@ public class SearchBar extends RelativeLayout implements View.OnClickListener,
                 defaultClientSuggestionsAdapter.clear();
                 recyclerView.setAdapter(defaultClientSuggestionsAdapter);
             }
-
-            if(defaultClientSuggestionsAdapter != null) {
-                defaultClientSuggestionsAdapter.clear();
-                recyclerView.setAdapter(defaultClientSuggestionsAdapter);
-            }
         }
         else if (id == R.id.arrow || !navIconShown) {
             disableSearch();
-
-            if(defaultClientSuggestionsAdapter != null) {
-                defaultClientSuggestionsAdapter.clear();
-                recyclerView.setAdapter(defaultClientSuggestionsAdapter);
-            }
 
             if(defaultClientSuggestionsAdapter != null) {
                 defaultClientSuggestionsAdapter.clear();


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build is passing successfully
- [ ] All tests are passing 
- [ ] PR is a breaking change (might cause older versions to break)

## Fixes issue

<!-- Add the issue number this PR fixes after hashtag --> 

Fixes: #24  


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- #24 DefaultClientSuggestionsAdapter is cleared multiple times
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- DefaultClientSuggestionsAdapter is cleared and set only once
-


## Other information

<!-- Any other information that is important to this PR. -->

None

